### PR TITLE
Color and selected tab fixes

### DIFF
--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -22,7 +22,7 @@
     text-align: center;
 
 	/* Tab cursor must be pointer in .tab */
-	cursor: pointer;
+	//cursor: pointer;
 
     &.active {
       font-weight: bold;
@@ -42,11 +42,14 @@
     }
 
     // Close Icon (the X) -------------------
-    .close-icon:hover {
-      color: @text-color-selected;
+	// They must continue with their colors and inherit the cursor
+	.close-icon:hover {
+      color: @text-color;
+	  cursor: pointer;
     }
     &.active .close-icon:hover {
-      color: @text-color;
+      color: @text-color-selected;
+	  cursor: pointer;
     }
 
     // Dragging -------------------

--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -18,8 +18,8 @@
   .list-item {
     color: @text-color;
   }
-  
+
   .list-item.selected {
-    color: @text-color-selected;
+    color: @text-color; // The color will be the same as default
   }
 }

--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -19,7 +19,7 @@
 @text-color:           #ff3300;
 @text-color-subtle:    #ff3300;
 @text-color-highlight: #ff3300;
-@text-color-selected:  #ff3300;
+@text-color-selected:  #220000; // The dark "red" color
 
 @text-color-info:    hsl(219,  79%, 66%);
 @text-color-success: hsl(140,  44%, 62%);


### PR DESCRIPTION
Some corrections.
The selected tab was "all" light red after the last update. 
It's now OK in my ATOM client.

Thanks for now.