### PR TITLE
Applied overrides solving some active styles in UI

### DIFF
--- a/index.less
+++ b/index.less
@@ -17,6 +17,7 @@
 @import "styles/lists";
 @import "styles/panels";
 @import "styles/progress";
+@import "styles/settings";
 @import "styles/sites";
 @import "styles/status-bar";
 @import "styles/tabs";

--- a/styles/git.less
+++ b/styles/git.less
@@ -11,3 +11,10 @@
 .list-item.status-modified { font-weight: 800; font-style: italic;} // orange
 .status-removed  { color: @text-color-error; }   // red
 .status-renamed  { color: @text-color-info; }    // blue
+
+
+// Git Panel UI - Stash, structure and fields
+// -------------------
+// 
+.github-StagingView-group.is-focused .is-selected { color: @text-color-highlight; } // Stash active item
+.github-CommitView-editor { background-color: @backgroundColor; } // Git message editor

--- a/styles/lists.less
+++ b/styles/lists.less
@@ -23,10 +23,9 @@
 // List Tree -------------------
 .list-tree {
   .selected {
-    color: @text-color-selected;
+    color: @text-color-highlight; // Lighter color, darker can't be read
   }
 }
-
 
 // Select List -------------------
 .select-list {

--- a/styles/settings.less
+++ b/styles/settings.less
@@ -1,0 +1,7 @@
+
+// Settings
+// -------------------
+
+// Used override settings default styles
+
+.settings-view .config-menu .nav > li.active > a { color: @text-color-highlight; } // Settings menu item active override


### PR DESCRIPTION
I have some issues in my Atom with active itens. 

It happens in some different places and components, and I'm purposing the changes I've done locally for your analysis as a pull request.

In general, the overrides solve some colors in active items at git panel structures, settings and lists. 

There's a new less file for settings.

Regards,
Rodrigo